### PR TITLE
resetThread functioning 

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,11 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+
+[dev-packages]
+
+[requires]
+python_version = "2.7"

--- a/src/blocks/scratch3_countdown.js
+++ b/src/blocks/scratch3_countdown.js
@@ -69,7 +69,6 @@ class Scratch3Countdown {
                 this.touchedSattleite = '';
                 this.isSatelliteTouched = !!(data.touched);
             }
-          
             console.log(this.touchedSattleite, 'touched sat', this.isSatelliteTouched, 'is sat touched');
         });
 
@@ -122,7 +121,7 @@ class Scratch3Countdown {
             message_sendGameMQTT: this.sendGameMQTT,
             message_receiveGameMQTT: this.listenToTopicMQTT,
             message_waitUntilBroadcast: this.waitUntil,
-            message_resetgame: this.resetGame,
+            message_resetThread: this.resetThread,
             countdown_gameMode: this.gameMode,
             countdown_startCelebration: this.startCelebration,
             countdown_whenTimerStarted: this.whenTimerStarted,
@@ -142,7 +141,7 @@ class Scratch3Countdown {
     gameMode (args, util) {
         this.runtime.emit('CHECK_MODE', args);
         const condition = this.mode_match;
-      
+    
         if (!condition) {
             util.yield();
         }
@@ -157,10 +156,10 @@ class Scratch3Countdown {
     }
 
     sendGameMQTT (args, util) {
-        if (args.TOPIC === '' ||
-      args.TOPIC === 'topic' ||
-      args.VALUE === '' ||
-      args.VALUE === 'value') {
+        if (    args.TOPIC === '' ||
+                args.TOPIC === 'topic' ||
+                args.VALUE === '' ||
+                args.VALUE === 'value') {
             return;
         }
         const topic = args.TOPIC.split('/');
@@ -213,7 +212,7 @@ class Scratch3Countdown {
     }
 
     waitUntil (args, util) {
-        console.log(args, 'args from waitUtil');
+        console.log(args, 'args from waitUntil');
         const topic = args.TOPIC.split('/');
         const last = topic.length - 1;
         const action = topic[last];
@@ -298,9 +297,11 @@ class Scratch3Countdown {
         }
     }
 
-    resetGame () {
+    resetThread (args, util) {
         this.runtime.emit('RESET_GAME');
-        this.runtime.greenFlag();
+        // params: (branchNum, isLoop) 
+        util.startBranchFromTopBlock(1, false);
+        
     }
 }
 

--- a/src/blocks/scratch3_looks.js
+++ b/src/blocks/scratch3_looks.js
@@ -333,6 +333,7 @@ class Scratch3LooksBlocks {
     }
 
     sayforsecs (args, util) {
+        // debugger
         this.say(args, util);
         const target = util.target;
         const usageId = this._getBubbleState(target).usageId;

--- a/src/engine/block-utility.js
+++ b/src/engine/block-utility.js
@@ -125,6 +125,13 @@ class BlockUtility {
     }
 
     /**
+     * For sending the computational thread to the topblock, testing as of 5/6/21
+     */
+    startBranchFromTopBlock (branchNum, isLoop) {
+        this.sequencer.stepToTopBlock(this.thread, branchNum, isLoop);
+    }
+
+    /**
      * Stop all threads.
      */
     stopAll () {

--- a/src/engine/mqttControl.js
+++ b/src/engine/mqttControl.js
@@ -68,7 +68,7 @@ class MqttControl extends EventEmitter{
 
 
     static onMessage (topic, payload, runtime) {
-        // console.log(`onMessage fired for topic: ${topic}, payload: ${payload}`);
+        console.log(`onMessage fired for topic: ${topic}, payload: ${payload}`);
         this.runtime = runtime;
         const t = topic.split('/');
         console.log(topic, 'topics');

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -765,6 +765,7 @@ class Runtime extends EventEmitter {
      */
     _registerBlockPackages () {
         for (const packageName in defaultBlockPackages) {
+            // debugger
             if (defaultBlockPackages.hasOwnProperty(packageName)) {
                 // @todo pass a different runtime depending on package privilege?
                 const packageObject = new (defaultBlockPackages[packageName])(this);

--- a/src/engine/sequencer.js
+++ b/src/engine/sequencer.js
@@ -303,18 +303,12 @@ class Sequencer {
      * For sending the computational thread to the topblock, testing as of 5/6/21
      */
     stepToTopBlock (thread, branchNum, isLoop) {
-        // debugger
         if (!branchNum) {
             branchNum = 1;
         }
         const topBlockId = thread.topBlock;
-        // const branchId = thread.target.blocks.getBranch(
-        //     currentBlockId,
-        //     branchNum
-        // );
         thread.peekStackFrame().isLoop = isLoop;
         if (topBlockId) {
-            // Push branch ID to the thread's stack.
             thread.pushStack(topBlockId);
         } else {
             thread.pushStack(null);

--- a/src/engine/sequencer.js
+++ b/src/engine/sequencer.js
@@ -300,6 +300,28 @@ class Sequencer {
     }
 
     /**
+     * For sending the computational thread to the topblock, testing as of 5/6/21
+     */
+    stepToTopBlock (thread, branchNum, isLoop) {
+        // debugger
+        if (!branchNum) {
+            branchNum = 1;
+        }
+        const topBlockId = thread.topBlock;
+        // const branchId = thread.target.blocks.getBranch(
+        //     currentBlockId,
+        //     branchNum
+        // );
+        thread.peekStackFrame().isLoop = isLoop;
+        if (topBlockId) {
+            // Push branch ID to the thread's stack.
+            thread.pushStack(topBlockId);
+        } else {
+            thread.pushStack(null);
+        }
+    }
+
+    /**
      * Step a procedure.
      * @param {!Thread} thread Thread object to step to procedure.
      * @param {!string} procedureCode Procedure code of procedure to step to.

--- a/src/extensions/scratch3_playspot/index.js
+++ b/src/extensions/scratch3_playspot/index.js
@@ -1550,7 +1550,7 @@ class Scratch3PlayspotBlocks {
         }
     }
 
-    resetGame () {
+    resetThread () {
         this.runtime.emit('RESET_GAME');
         this.runtime.gameGreenFlag();
     }


### PR DESCRIPTION
stepToTopBlock on sequencer.js

changed message_resetgame to message_resetThread on scratch3_countdown.js

tested and debugged

### Resolves

_What Github issue does this resolve (please include link)?_

https://github.com/orgs/ComputeCycles/projects/1#card-60111195

### Proposed Changes

_Describe what this Pull Request does_

creates a new chain of functions that point the computational thread of a given stack of blocks explicitly back to its topBlock aka the top/Hat block in our use case

### Reason for Changes

_Explain why these changes should be made_

### Test Coverage

_Please show how you have added tests to cover your changes_
