### PR TITLE
added .emit('RESET_THEAD') to .emit('RESET_GAME') instances

### DIFF
--- a/src/blocks/scratch3_countdown.js
+++ b/src/blocks/scratch3_countdown.js
@@ -110,6 +110,13 @@ class Scratch3Countdown {
                 this.actions[i] = {[`${keys[0]}`]: false};
             }
         });
+        // Duplicate of above but for new RESET_THREAD 
+        this.runtime.on('RESET_THREAD', () => {
+            for (let i = 0; i < this.actions.length; i++) {
+                const keys = Object.keys(this.actions[i]);
+                this.actions[i] = {[`${keys[0]}`]: false};
+            }
+        });
     }
 
     /**
@@ -298,6 +305,7 @@ class Scratch3Countdown {
     }
 
     resetThread (args, util) {
+        this.runtime.emit('RESET_THREAD');
         this.runtime.emit('RESET_GAME');
         // params: (branchNum, isLoop) 
         util.startBranchFromTopBlock(1, false);

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -178,6 +178,10 @@ class VirtualMachine extends EventEmitter {
         this.runtime.on('RESET_GAME', data => {
             this.emit('RESET_GAME', data);
         });
+        // Duplicate of above but for new RESET_THREAD 
+        this.runtime.on('RESET_THREAD', data => {
+            this.emit('RESET_THREAD', data);
+        });
         this.runtime.on('SEND_SOUND', data => {
             this.emit('SEND_SOUND', data);
         });


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

### Proposed Changes

_Describe what this Pull Request does_

Adds .emit('RESET_THEAD') to instances of .emit('RESET_GAME')  

WITH THE EXCEPTION of on srs/extensions/scratch3_playspot/index.js

### Reason for Changes

_Explain why these changes should be made_

now sure what this.runtime.emit('RESET_GAME'); does for functionality, don't want anything to break

### Test Coverage

_Please show how you have added tests to cover your changes_
