### PR TITLE
Bvs/sat vars fix

### DIFF
--- a/src/engine/mqttControl.js
+++ b/src/engine/mqttControl.js
@@ -228,7 +228,7 @@ class MqttControl extends EventEmitter{
             hasPresence: false
         };
         this.runtime.emit('SET_SATELLITE_VARS', sender);
-        this.runtime.emit('SET_SATELLITES', satellites);
+        this.runtime.emit('SET_ALL_SATELLITES', satellites);
     }
 
     static firmwareHandler (payload) {

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -199,12 +199,12 @@ class VirtualMachine extends EventEmitter {
                 this.client.publish(outboundTopic, arr);
             }
         });
-        this.runtime.on('SET_SATELLITES', data => {
-            this.setSatellites(data);
-            this.emit('SET_SATELLITES', data);
+        this.runtime.on('SET_ALL_SATELLITES', data => {
+            this.setAllSatellites(data);
+            this.emit('SET_ALL_SATELLITES', data);
         });
         this.runtime.on('SET_SATELLITE_VARS', data => {
-            this.createSatelliteVariables(data);
+            this.createSatelliteVariable(data);
             this.emit('SET_SATELLITE_VARS', data);
         });
         this.runtime.on('SET_SOUND_VARS', data => {
@@ -354,10 +354,6 @@ class VirtualMachine extends EventEmitter {
         return this.satellites;
     }
 
-    setSatellites (satellites) {
-        this.satellites = satellites;
-    }
-
     addSubscriptions (topic) {
         if (this.client && topic !== 'topic') {
             this.client.subscribe(topic);
@@ -403,7 +399,7 @@ class VirtualMachine extends EventEmitter {
         }
         setTimeout(() => {
             stage.variables[allSounds.id_].value = wavs.map(currentValue => currentValue.replace('.wav', ''));
-        }, 5000);
+        }, 100);
     }
 
     createLightVariables (data) {
@@ -414,28 +410,31 @@ class VirtualMachine extends EventEmitter {
         }
         setTimeout(() => {
             stage.variables[allLights.id_].value = data.map(currentValue => currentValue.replace('.txt', ''));
-        }, 5000);
+        }, 100);
         this.runtime.emit(this.runtime.constructor.CLIENT_CONNECTED);
     }
 
-    createSatelliteVariables (data) {
+    setAllSatellites (satellites) {
+        this.satellites = satellites;
         const stage = this.runtime.getTargetForStage();
         let allSats = stage.lookupVariableByNameAndType('All_Satellites', 'list');
-        let singleSat = stage.lookupVariableByNameAndType(`${data}`, '');
         if (!allSats) {
             allSats = this.workspace.createVariable(`All_Satellites`, 'list', false, false);
         }
+        setTimeout(() => {
+            stage.variables[allSats.id_].value = Object.keys(this.satellites);
+        }, 100);
+    }
+
+    createSatelliteVariable (data) {
+        const stage = this.runtime.getTargetForStage();
+        let singleSat = stage.lookupVariableByNameAndType(`${data}`, '');
         if (!singleSat) {
             singleSat = this.workspace.createVariable(`${data}`, '', false, false);
         }
-        if (singleSat && !singleSat.value) {
-            // debugger
-            singleSat.value = data;
-        }
         setTimeout(() => {
-            stage.variables[allSats.id_].value = Object.keys(this.satellites);
             stage.variables[singleSat.id_].value = `${data}`;
-        }, 5000);
+        }, 100);
     }
 
     /**

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -428,6 +428,14 @@ class VirtualMachine extends EventEmitter {
         if (!singleSat) {
             singleSat = this.workspace.createVariable(`${data}`, '', false, false);
         }
+        if (singleSat && !singleSat.value) {
+            // debugger
+            singleSat.value = data;
+        }
+        setTimeout(() => {
+            stage.variables[allSats.id_].value = Object.keys(this.satellites);
+            stage.variables[singleSat.id_].value = `${data}`;
+        }, 5000);
     }
 
     /**


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

https://github.com/ComputeCycles/playspots-education-gui/issues/23

### Proposed Changes

_Describe what this Pull Request does_

separates creation of allSats list variable and individual sat variables into two separate functions on vitual-machine.js

renames SET_SATELLITES to SET_ALL_SATELLITES event for clarity
### Reason for Changes

_Explain why these changes should be made_

list of all sats and individual sat variable values were not loading in before

### Test Coverage

_Please show how you have added tests to cover your changes_

tested and working in scratch 3 dev gui on both `10.8.0.5` and `10.8.0.28`
