### PR TITLE
radar sensitivity publications now include "retain: true" flag

### DIFF
--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -264,23 +264,26 @@ class VirtualMachine extends EventEmitter {
             this.emit('HAS_PRESENCE', data);
         });
         this.runtime.on('SET_RADAR', data => {
-            const utf8Encode = new TextEncoder();
-            const options = {qos: 0};
-            const fSpeedTopic = `sat/${data.SATELLITE}/cfg/radar/fSpeed`;
-            const bSpeedTopic = `sat/${data.SATELLITE}/cfg/radar/bSpeed`;
-            const fMagTopic = `sat/${data.SATELLITE}/cfg/radar/fMag`;
-            const bMagTopic = `sat/${data.SATELLITE}/cfg/radar/bMag`;
-            const detEnTopic = `sat/${data.SATELLITE}/cfg/radar/detEn`;
-
-            if (this.client && this.client != undefined) {
-                if (data.SENSITIVITY == "off") {
-                    this.client.publish(detEnTopic, utf8Encode.encode('0'), options);
-                } else {
-                    this.client.publish(detEnTopic, utf8Encode.encode('1'), options);
-                    this.client.publish(fSpeedTopic, utf8Encode.encode('2'), options);
-                    this.client.publish(bSpeedTopic, utf8Encode.encode('2'), options);
-                    this.client.publish(fMagTopic, utf8Encode.encode('5'), options);
-                    this.client.publish(bMagTopic, utf8Encode.encode('5'), options);
+            if (data.SATELLITE !== 'satellite') {
+                
+                const utf8Encode = new TextEncoder();
+                const options = {qos: 0, retain: true};
+                const fSpeedTopic = `sat/${data.SATELLITE}/cfg/radar/fSpeed`;
+                const bSpeedTopic = `sat/${data.SATELLITE}/cfg/radar/bSpeed`;
+                const fMagTopic = `sat/${data.SATELLITE}/cfg/radar/fMag`;
+                const bMagTopic = `sat/${data.SATELLITE}/cfg/radar/bMag`;
+                const detEnTopic = `sat/${data.SATELLITE}/cfg/radar/detEn`;
+                
+                if (this.client && this.client != undefined) {
+                    if (data.SENSITIVITY == "off") {
+                        this.client.publish(detEnTopic, utf8Encode.encode('0'), options);
+                    } else {
+                        this.client.publish(detEnTopic, utf8Encode.encode('1'), options);
+                        this.client.publish(fSpeedTopic, utf8Encode.encode('2'), options);
+                        this.client.publish(bSpeedTopic, utf8Encode.encode('2'), options);
+                        this.client.publish(fMagTopic, utf8Encode.encode('5'), options);
+                        this.client.publish(bMagTopic, utf8Encode.encode('5'), options);
+                    }
                 }
             }
         });


### PR DESCRIPTION


### Resolves

_What Github issue does this resolve (please include link)?_

https://github.com/ComputeCycles/playspots-education-blocks/issues/16

### Proposed Changes

_Describe what this Pull Request does_

adds `retain: true` to options param of publications to client setting radar sensitivity for individual sats

### Reason for Changes

_Explain why these changes should be made_

so radar settings don't have to be reestablished every time a sat is connected/disconnected from the MQTT network

### Test Coverage

_Please show how you have added tests to cover your changes_

only tested locally on my machine with one sat, also created a dummy sat variable on mqtt server and its radar settings are also successfully retained
