### PR TITLE
VM now subscribes to topics "alias/+" and "group/+" on Connect, creat…

### DIFF
--- a/src/engine/mqttConnect.js
+++ b/src/engine/mqttConnect.js
@@ -112,8 +112,8 @@ class MqttConnect extends EventEmitter {
             this._client.subscribe('sat/+/ev/touch');
             this._client.subscribe('+/sat/+/ev/touch');
             this._client.subscribe('app/menu/mode');
-            // for testing: 
-            this._client.subscribe('sat/+/mode');
+            this._client.subscribe('alias/+');
+            this._client.subscribe('group/+');
             this.runtime.emit(this.runtime.constructor.CLIENT_CONNECTED);
         }
 

--- a/src/engine/mqttControl.js
+++ b/src/engine/mqttControl.js
@@ -102,20 +102,24 @@ class MqttControl extends EventEmitter{
             }
         } else if (t[0] === 'alias') {
             const parsedPayload = decoder.decode(payload);
-            const json = JSON.parse(parsedPayload);
-            const data = {
-                payload: json,
-                alias: t[1]
-            };
-            this.runtime.emit('MQTT_ALIAS_VAR_INBOUND', data);
+            if (this.IsJson(parsedPayload)) {
+                const json = JSON.parse(parsedPayload);
+                const data = {
+                    payload: json,
+                    alias: t[1]
+                };
+                this.runtime.emit('MQTT_ALIAS_VAR_INBOUND', data);
+            }
         } else if (t[0] === 'group') {
             const parsedPayload = decoder.decode(payload);
-            const json = JSON.parse(parsedPayload);
-            const data = {
-                payload: json,
-                group: t[1]
-            };
-            this.runtime.emit('MQTT_GROUP_VAR_INBOUND', data);
+            if (this.IsJson(parsedPayload)) {
+                const json = JSON.parse(parsedPayload);
+                const data = {
+                    payload: json,
+                    group: t[1]
+                };
+                this.runtime.emit('MQTT_GROUP_VAR_INBOUND', data);
+            }
         } else if (t[0] === 'sat' && t[2] === 'cmd' && t[3] === 'fx') {
             const message = decoder.decode(payload);
             // this.props.setProjectState(true);
@@ -404,6 +408,15 @@ class MqttControl extends EventEmitter{
         // this.runtime.emit('PUBLISH_TO_CLIENT', data);
         // // this._client.publish(outboundTopic, arr);
         // return Promise.resolve();
+    }
+
+    static IsJson (variable) {
+        try {
+            JSON.parse(variable);
+        } catch (e) {
+            return false;
+        }
+        return true;
     }
 }
 

--- a/src/engine/mqttControl.js
+++ b/src/engine/mqttControl.js
@@ -100,13 +100,22 @@ class MqttControl extends EventEmitter{
             if (this.props) {
                 this.props.vm.modeHandler(payload); // this is a presence message
             }
-        } else if (t[0] === 'sat' && t[2] === 'mode') {
+        } else if (t[0] === 'alias') {
             const parsedPayload = decoder.decode(payload);
+            const json = JSON.parse(parsedPayload);
             const data = {
-                payload: parsedPayload,
-                topic: topic
+                payload: json,
+                alias: t[1]
             };
-            this.runtime.emit('MQTT_SAT_X_MODE_INBOUND', data);
+            this.runtime.emit('MQTT_ALIAS_VAR_INBOUND', data);
+        } else if (t[0] === 'group') {
+            const parsedPayload = decoder.decode(payload);
+            const json = JSON.parse(parsedPayload);
+            const data = {
+                payload: json,
+                group: t[1]
+            };
+            this.runtime.emit('MQTT_GROUP_VAR_INBOUND', data);
         } else if (t[0] === 'sat' && t[2] === 'cmd' && t[3] === 'fx') {
             const message = decoder.decode(payload);
             // this.props.setProjectState(true);

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -545,20 +545,23 @@ class VirtualMachine extends EventEmitter {
     }
 
     setAliasVariables (data) {
-        const stage = this.runtime.getTargetForStage();
-        const aliasVariable = this.workspace.createVariable(`${data.alias}`, '', false, false);
-        setTimeout(() => {
-            stage.variables[aliasVariable.id_].value = data.payload;
-        }, 100);
-            
+        if (typeof data.payload === 'string' && data.payload !== '') {
+            const stage = this.runtime.getTargetForStage();
+            const aliasVariable = this.workspace.createVariable(`${data.alias}`, '', false, false);
+            setTimeout(() => {
+                stage.variables[aliasVariable.id_].value = data.payload;
+            }, 100);
+        }    
     }
 
     setGroupVariables (data) {
-        const stage = this.runtime.getTargetForStage();
-        const groupVariable = this.workspace.createVariable(`${data.group}`, 'list', false, false);
-        setTimeout(() => {
-            stage.variables[groupVariable.id_].value = data.payload;
-        }, 100);
+        if (Array.isArray(data.payload) && data.payload !== []) {
+            const stage = this.runtime.getTargetForStage();
+            const groupVariable = this.workspace.createVariable(`${data.group}`, 'list', false, false);
+            setTimeout(() => {
+                stage.variables[groupVariable.id_].value = data.payload;
+            }, 100);
+        }
     }
 
     clearAllScratchVariables () {

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -347,6 +347,14 @@ class VirtualMachine extends EventEmitter {
         this.runtime.on('DISCONNECT_FROM_MQTT', () => {
             this.DisconnectMqtt();
         });
+        
+        this.runtime.on('MQTT_ALIAS_VAR_INBOUND', data => {
+            this.setAliasVariables(data);
+        });
+        
+        this.runtime.on('MQTT_GROUP_VAR_INBOUND', data => {
+            this.setGroupVariables(data);
+        });
 
         this.extensionManager = new ExtensionManager(this.runtime);
 
@@ -536,10 +544,27 @@ class VirtualMachine extends EventEmitter {
         }
     }
 
+    setAliasVariables (data) {
+        const stage = this.runtime.getTargetForStage();
+        const aliasVariable = this.workspace.createVariable(`${data.alias}`, '', false, false);
+        setTimeout(() => {
+            stage.variables[aliasVariable.id_].value = data.payload;
+        }, 100);
+            
+    }
+
+    setGroupVariables (data) {
+        const stage = this.runtime.getTargetForStage();
+        const groupVariable = this.workspace.createVariable(`${data.group}`, 'list', false, false);
+        setTimeout(() => {
+            stage.variables[groupVariable.id_].value = data.payload;
+        }, 100);
+    }
+
     clearAllScratchVariables () {
-        const variablesToClear = this.runtime.getTargetForStage().variables;
-        for (const variable in variablesToClear) {
-            this.workspace.deleteVariableById(variable);
+        const variableIds = Object.keys(this.runtime.getTargetForStage().variables);
+        for (let i = 0; i < variableIds.length; i++) {
+            this.workspace.deleteVariableById(variableIds[i]);
         }
     }
 


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

https://github.com/orgs/ComputeCycles/projects/1#card-61629546

### Proposed Changes

_Describe what this Pull Request does_

1. Subscribes MQTT Client to 'alias/+' and 'group/+' on connect
2. Creates list or string variables from the retained data items on above topics on Connect
3. ALL such variables are cleared on disconnect

4. IMPROVES loop efficiency for `clearAllScratchVariables` created for last PR

### Reason for Changes

_Explain why these changes should be made_

### Test Coverage

_Please show how you have added tests to cover your changes_
