### PR TITLE
Bvs/all vars on connect

### DIFF
--- a/src/engine/mqttConnect.js
+++ b/src/engine/mqttConnect.js
@@ -112,8 +112,8 @@ class MqttConnect extends EventEmitter {
             this._client.subscribe('sat/+/ev/touch');
             this._client.subscribe('+/sat/+/ev/touch');
             this._client.subscribe('app/menu/mode');
-            // for testing: 
-            this._client.subscribe('sat/+/mode');
+            this._client.subscribe('alias/+');
+            this._client.subscribe('group/+');
             this.runtime.emit(this.runtime.constructor.CLIENT_CONNECTED);
         }
 

--- a/src/engine/mqttControl.js
+++ b/src/engine/mqttControl.js
@@ -102,20 +102,24 @@ class MqttControl extends EventEmitter{
             }
         } else if (t[0] === 'alias') {
             const parsedPayload = decoder.decode(payload);
-            const json = JSON.parse(parsedPayload);
-            const data = {
-                payload: json,
-                alias: t[1]
-            };
-            this.runtime.emit('MQTT_ALIAS_VAR_INBOUND', data);
+            if (this.IsJson(parsedPayload)) {
+                const json = JSON.parse(parsedPayload);
+                const data = {
+                    payload: json,
+                    alias: t[1]
+                };
+                this.runtime.emit('MQTT_ALIAS_VAR_INBOUND', data);
+            }
         } else if (t[0] === 'group') {
             const parsedPayload = decoder.decode(payload);
-            const json = JSON.parse(parsedPayload);
-            const data = {
-                payload: json,
-                group: t[1]
-            };
-            this.runtime.emit('MQTT_GROUP_VAR_INBOUND', data);
+            if (this.IsJson(parsedPayload)) {
+                const json = JSON.parse(parsedPayload);
+                const data = {
+                    payload: json,
+                    group: t[1]
+                };
+                this.runtime.emit('MQTT_GROUP_VAR_INBOUND', data);
+            }
         } else if (t[0] === 'sat' && t[2] === 'cmd' && t[3] === 'fx') {
             const message = decoder.decode(payload);
             // this.props.setProjectState(true);
@@ -404,6 +408,15 @@ class MqttControl extends EventEmitter{
         // this.runtime.emit('PUBLISH_TO_CLIENT', data);
         // // this._client.publish(outboundTopic, arr);
         // return Promise.resolve();
+    }
+
+    static IsJson (variable) {
+        try {
+            JSON.parse(variable);
+        } catch (e) {
+            return false;
+        }
+        return true;
     }
 }
 

--- a/src/engine/mqttControl.js
+++ b/src/engine/mqttControl.js
@@ -7,12 +7,12 @@ let _sequencesByName = {};
 // import SoundFiles from '../lib/soundFiles';
 let touchedSatVars = {
     ALL_SAT_TOUCH_SATID: '',
-    ALL_SAT_TOUCH_VALUE: ''
+    ALL_SAT_TOUCH_VALUE: 0
 };
 
 let radarSatVars = {
     ALL_SAT_RADAR_SATID: '',
-    ALL_SAT_RADAR_VALUE: ''
+    ALL_SAT_RADAR_VALUE: 0
 };
 
 class MqttControl extends EventEmitter{
@@ -266,8 +266,12 @@ class MqttControl extends EventEmitter{
             isTouched: false,
             hasPresence: false
         };
+        touchedSatVars.ALL_SAT_TOUCH_SATID = sender;
+        radarSatVars.ALL_SAT_RADAR_SATID = sender;
         this.runtime.emit('SET_SATELLITE_VARS', sender);
         this.runtime.emit('SET_ALL_SATELLITES', satellites);
+        this.runtime.emit('SET_TOUCH_VARS', touchedSatVars);
+        this.runtime.emit('SET_RADAR_VARS', radarSatVars);
     }
 
     static firmwareHandler (payload) {

--- a/src/engine/mqttControl.js
+++ b/src/engine/mqttControl.js
@@ -100,13 +100,22 @@ class MqttControl extends EventEmitter{
             if (this.props) {
                 this.props.vm.modeHandler(payload); // this is a presence message
             }
-        } else if (t[0] === 'sat' && t[2] === 'mode') {
+        } else if (t[0] === 'alias') {
             const parsedPayload = decoder.decode(payload);
+            const json = JSON.parse(parsedPayload);
             const data = {
-                payload: parsedPayload,
-                topic: topic
+                payload: json,
+                alias: t[1]
             };
-            this.runtime.emit('MQTT_SAT_X_MODE_INBOUND', data);
+            this.runtime.emit('MQTT_ALIAS_VAR_INBOUND', data);
+        } else if (t[0] === 'group') {
+            const parsedPayload = decoder.decode(payload);
+            const json = JSON.parse(parsedPayload);
+            const data = {
+                payload: json,
+                group: t[1]
+            };
+            this.runtime.emit('MQTT_GROUP_VAR_INBOUND', data);
         } else if (t[0] === 'sat' && t[2] === 'cmd' && t[3] === 'fx') {
             const message = decoder.decode(payload);
             // this.props.setProjectState(true);

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -492,7 +492,7 @@ class VirtualMachine extends EventEmitter {
         }
 
         let singleSatTouchValue = stage.lookupVariableByNameAndType(`${touchedSatVars.ALL_SAT_TOUCH_SATID}_TOUCH_VALUE`, '');
-        if (!singleSatTouchValue) {
+        if (!singleSatTouchValue && touchedSatVars.ALL_SAT_TOUCH_SATID !== '') {
             singleSatTouchValue = this.workspace.createVariable(`${touchedSatVars.ALL_SAT_TOUCH_SATID}_TOUCH_VALUE`, '', false, false);
             
             setTimeout(() => {
@@ -504,7 +504,7 @@ class VirtualMachine extends EventEmitter {
         }
     }
 
-    setRadarVariables (touchedSatVars) {
+    setRadarVariables (radarSatVars) {
         const stage = this.runtime.getTargetForStage();
         
         let allSatRadarSatIdVar = stage.lookupVariableByNameAndType('ALL_SAT_RADAR_SATID', '');
@@ -512,11 +512,11 @@ class VirtualMachine extends EventEmitter {
             allSatRadarSatIdVar = this.workspace.createVariable('ALL_SAT_RADAR_SATID', '', false, false);
             
             setTimeout(() => {
-                stage.variables[allSatRadarSatIdVar.id_].value = `${touchedSatVars.ALL_SAT_RADAR_SATID}`;
+                stage.variables[allSatRadarSatIdVar.id_].value = `${radarSatVars.ALL_SAT_RADAR_SATID}`;
             }, 100);
         }
         if (allSatRadarSatIdVar) {
-            allSatRadarSatIdVar.value = touchedSatVars.ALL_SAT_RADAR_SATID;
+            allSatRadarSatIdVar.value = radarSatVars.ALL_SAT_RADAR_SATID;
         }
 
         let allSatRadarValue = stage.lookupVariableByNameAndType('ALL_SAT_RADAR_VALUE', '');
@@ -524,23 +524,23 @@ class VirtualMachine extends EventEmitter {
             allSatRadarValue = this.workspace.createVariable('ALL_SAT_RADAR_VALUE', '', false, false);
             
             setTimeout(() => {
-                stage.variables[allSatRadarValue.id_].value = `${touchedSatVars.ALL_SAT_RADAR_VALUE}`;
+                stage.variables[allSatRadarValue.id_].value = `${radarSatVars.ALL_SAT_RADAR_VALUE}`;
             }, 100);
         }
         if (allSatRadarValue) {
-            allSatRadarValue.value = touchedSatVars.ALL_SAT_RADAR_VALUE;
+            allSatRadarValue.value = radarSatVars.ALL_SAT_RADAR_VALUE;
         }
 
-        let singleSatRadarValue = stage.lookupVariableByNameAndType(`${touchedSatVars.ALL_SAT_RADAR_SATID}_RADAR_VALUE`, '');
-        if (!singleSatRadarValue) {
-            singleSatRadarValue = this.workspace.createVariable(`${touchedSatVars.ALL_SAT_RADAR_SATID}_RADAR_VALUE`, '', false, false);
+        let singleSatRadarValue = stage.lookupVariableByNameAndType(`${radarSatVars.ALL_SAT_RADAR_SATID}_RADAR_VALUE`, '');
+        if (!singleSatRadarValue && radarSatVars.ALL_SAT_RADAR_SATID !== '') {
+            singleSatRadarValue = this.workspace.createVariable(`${radarSatVars.ALL_SAT_RADAR_SATID}_RADAR_VALUE`, '', false, false);
             
             setTimeout(() => {
-                stage.variables[singleSatRadarValue.id_].value = `${touchedSatVars.ALL_SAT_RADAR_VALUE}`;
+                stage.variables[singleSatRadarValue.id_].value = `${radarSatVars.ALL_SAT_RADAR_VALUE}`;
             }, 100);
         }
         if (singleSatRadarValue) {
-            singleSatRadarValue.value = touchedSatVars.ALL_SAT_RADAR_VALUE;
+            singleSatRadarValue.value = radarSatVars.ALL_SAT_RADAR_VALUE;
         }
     }
 

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -545,20 +545,23 @@ class VirtualMachine extends EventEmitter {
     }
 
     setAliasVariables (data) {
-        const stage = this.runtime.getTargetForStage();
-        const aliasVariable = this.workspace.createVariable(`${data.alias}`, '', false, false);
-        setTimeout(() => {
-            stage.variables[aliasVariable.id_].value = data.payload;
-        }, 100);
-            
+        if (typeof data.payload === 'string' && data.payload !== '') {
+            const stage = this.runtime.getTargetForStage();
+            const aliasVariable = this.workspace.createVariable(`${data.alias}`, '', false, false);
+            setTimeout(() => {
+                stage.variables[aliasVariable.id_].value = data.payload;
+            }, 100);
+        }    
     }
 
     setGroupVariables (data) {
-        const stage = this.runtime.getTargetForStage();
-        const groupVariable = this.workspace.createVariable(`${data.group}`, 'list', false, false);
-        setTimeout(() => {
-            stage.variables[groupVariable.id_].value = data.payload;
-        }, 100);
+        if (Array.isArray(data.payload) && data.payload !== []) {
+            const stage = this.runtime.getTargetForStage();
+            const groupVariable = this.workspace.createVariable(`${data.group}`, 'list', false, false);
+            setTimeout(() => {
+                stage.variables[groupVariable.id_].value = data.payload;
+            }, 100);
+        }
     }
 
     clearAllScratchVariables () {

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -347,6 +347,14 @@ class VirtualMachine extends EventEmitter {
         this.runtime.on('DISCONNECT_FROM_MQTT', () => {
             this.DisconnectMqtt();
         });
+        
+        this.runtime.on('MQTT_ALIAS_VAR_INBOUND', data => {
+            this.setAliasVariables(data);
+        });
+        
+        this.runtime.on('MQTT_GROUP_VAR_INBOUND', data => {
+            this.setGroupVariables(data);
+        });
 
         this.extensionManager = new ExtensionManager(this.runtime);
 
@@ -536,10 +544,27 @@ class VirtualMachine extends EventEmitter {
         }
     }
 
+    setAliasVariables (data) {
+        const stage = this.runtime.getTargetForStage();
+        const aliasVariable = this.workspace.createVariable(`${data.alias}`, '', false, false);
+        setTimeout(() => {
+            stage.variables[aliasVariable.id_].value = data.payload;
+        }, 100);
+            
+    }
+
+    setGroupVariables (data) {
+        const stage = this.runtime.getTargetForStage();
+        const groupVariable = this.workspace.createVariable(`${data.group}`, 'list', false, false);
+        setTimeout(() => {
+            stage.variables[groupVariable.id_].value = data.payload;
+        }, 100);
+    }
+
     clearAllScratchVariables () {
-        const variablesToClear = this.runtime.getTargetForStage().variables;
-        for (const variable in variablesToClear) {
-            this.workspace.deleteVariableById(variable);
+        const variableIds = Object.keys(this.runtime.getTargetForStage().variables);
+        for (let i = 0; i < variableIds.length; i++) {
+            this.workspace.deleteVariableById(variableIds[i]);
         }
     }
 


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

https://github.com/orgs/ComputeCycles/projects/1#card-61629584

### Proposed Changes

_Describe what this Pull Request does_

1. All Playspot Vars load to Scratch Palette on MQTT Connect
2. changed `touchedSatVars` argument refs to more appropriate `radarSatVars` in  setRadarVariables function in the VM

### Reason for Changes

_Explain why these changes should be made_

### Test Coverage

_Please show how you have added tests to cover your changes_
