### PR TITLE
mqtt pubs on alias topics now automatically create message …

### DIFF
--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -373,6 +373,17 @@ class VirtualMachine extends EventEmitter {
         
         this.runtime.on('SET_ALIAS_VARS', data => {
             this.setAliasVariables(data);
+            const touchArgs = {};
+            const radarArgs = {};
+            touchArgs.MESSAGE = `${data.alias} Touch`;
+            touchArgs.TOPIC = `sat/${data.payload}/ev/touch`;
+            radarArgs.MESSAGE = `${data.alias} Radar`;
+            radarArgs.TOPIC = `sat/${data.payload}/ev/radar`;
+            this.satAliasBindings[touchArgs.TOPIC] = `${touchArgs.MESSAGE}`;
+            this.satAliasBindings[radarArgs.TOPIC] = `${radarArgs.MESSAGE}`;
+            console.log(this.satAliasBindings);
+            this.topicToMessage(touchArgs);
+            this.topicToMessage(radarArgs);
         });
         
         this.runtime.on('SET_GROUP_VARS', data => {


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

https://github.com/orgs/ComputeCycles/projects/1#card-63092346

https://github.com/orgs/ComputeCycles/projects/1#card-63083340

### Proposed Changes

_Describe what this Pull Request does_

1. MQTT alias variables now automatically create their own `broadcast_msg` variables to listen for touch/radar events, as well as "regular" scratch variables for the given alias' touch/radar input value 

### Reason for Changes

_Explain why these changes should be made_

### Test Coverage

_Please show how you have added tests to cover your changes_
